### PR TITLE
Prevent repeated evaluation of function in SUCCEEDED and FAILED macros

### DIFF
--- a/src/ODBC_API.jl
+++ b/src/ODBC_API.jl
@@ -66,12 +66,12 @@ end
 
 macro SUCCEEDED(func)
 	global ret = ret_lu(func)
-	:( ($func == SQL_SUCCESS || $func == SQL_SUCCESS_WITH_INFO) ? true : false )
+	:( return_code = $func; (return_code == SQL_SUCCESS || return_code == SQL_SUCCESS_WITH_INFO) ? true : false )
 end
 
 macro FAILED(func)
 	global ret = ret_lu(func)
-	:( ($func != SQL_SUCCESS && $func != SQL_SUCCESS_WITH_INFO) ? true : false )
+	:( return_code = $func; (return_code != SQL_SUCCESS && return_code != SQL_SUCCESS_WITH_INFO) ? true : false )
 end
 
 #http://msdn.microsoft.com/en-us/library/windows/desktop/ms712400(v=vs.85).aspx


### PR DESCRIPTION
Hi,

Whilst working on getting ODBC.jl to work with iODBC and Psqlodbc I was getting errors that the connection handle had already been established.

I dug through the code and noticed that the SUCCEEDED and FAILED macros would cause the function call expression to be evaluated twice. This was problematic for me- calling SQLDriverConnect would return SQL_SUCCESS_WITH_INFO, the second call to SQLDriverConnect would then cause the ODBC driver to return the error that the connection had already been established.

Sorry, I'm completely new to Julia so no idea whether the change I've made is idiomatic but it ensures the expression is evaluated only once.

Thanks for the library!

As an aside- I noticed you said you hadn't tried using it on a platform other than 32-bit Windows. I'm just getting started but I can successfully connect and run queries on 64-bit Mac OSX 10.8, using iODBC and psqlodbc (both installed through OSX Homebrew).
