### PR TITLE
Add WCHAR support using UTF16 package; fixes #13

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,0 +1,6 @@
+DataFrames v0.2.0
+Datetime
+ProgressMeter
+UTF16
+julia 0.2-
+

--- a/src/ODBC.jl
+++ b/src/ODBC.jl
@@ -3,6 +3,7 @@ module ODBC
 using DataFrames
 using Datetime
 using ProgressMeter
+using UTF16
 
 export advancedconnect, query, querymeta, @sql_str, Connection, Metadata, conn, Connections, disconnect, listdrivers, listdsns
 

--- a/src/ODBC_Types.jl
+++ b/src/ODBC_Types.jl
@@ -72,9 +72,9 @@ typealias SQLHWND Ptr{Void}
 # SQL_CHAR 							SQL_C_CHAR 							Uint8
 # SQL_VARCHAR 						SQL_C_CHAR 							Uint8
 # SQL_LONGVARCHAR 					SQL_C_CHAR 							Uint8
-# SQL_WCHAR 						SQL_C_WCHAR 						Uint8
-# SQL_WVARCHAR 						SQL_C_WCHAR 						Uint8
-# SQL_WLONGVARCHAR 					SQL_C_WCHAR 						Uint8
+# SQL_WCHAR 						SQL_C_WCHAR 						Uint16
+# SQL_WVARCHAR 						SQL_C_WCHAR 						Uint16
+# SQL_WLONGVARCHAR 					SQL_C_WCHAR 						Uint16
 # SQL_DECIMAL 						SQL_C_DOUBLE 						Float64									
 # SQL_NUMERIC 						SQL_C_DOUBLE 						Float64									
 # SQL_SMALLINT 						SQL_C_SHORT 						Int16
@@ -206,9 +206,9 @@ const SQL2Julia = [
 	SQL_CHAR=>Uint8,
 	SQL_VARCHAR=>Uint8,
 	SQL_LONGVARCHAR=>Uint8,
-	SQL_WCHAR=>Uint8,
-	SQL_WVARCHAR=>Uint8,
-	SQL_WLONGVARCHAR=>Uint8,
+	SQL_WCHAR=>Uint16,
+	SQL_WVARCHAR=>Uint16,
+	SQL_WLONGVARCHAR=>Uint16,
 	SQL_DECIMAL=>Float64,
 	SQL_NUMERIC=>Float64,
 	SQL_SMALLINT=>Int16,


### PR DESCRIPTION
For #13, it turns out that the return was an SQL_WVARCHAR, which is encoded as UTF16, not UTF8.  This seems only to be the case for things like "show table".

This patch adds support for UTF16 return types using the UTF16 package.  It works for me, but please look it over to see if I might have missed something or if it needs more conversions--it's late, and I might have missed something.  Or let me know if you have a different/better way to handle incoming UTF16 strings.
