### PR TITLE
Allow unixodbc in OSX

### DIFF
--- a/src/ODBC_Types.jl
+++ b/src/ODBC_Types.jl
@@ -6,7 +6,7 @@ let
     if !isdefined(:odbc_dm)
 	    @linux_only lib_choices = ["libodbc", "libodbc.so", "libodbc.so.1", "libodbc.so.2", "libodbc.so.3"]
 		@windows_only lib_choices = ["odbc32"]
-		@osx_only lib_choices = ["libiodbc","libiodbc.dylib","libiodbc.1.dylib","libiodbc.2.dylib","libiodbc.3.dylib"]
+		@osx_only lib_choices = ["libodbc.dylib","libiodbc","libiodbc.dylib","libiodbc.1.dylib","libiodbc.2.dylib","libiodbc.3.dylib"]
 	    for lib in lib_choices 
 	        try
 	            dlopen(lib)


### PR DESCRIPTION
I wanted to use unixODBC via a homebrew install on OSX. 
