### PR TITLE
remove various unsafe operations

### DIFF
--- a/src/ODBC.jl
+++ b/src/ODBC.jl
@@ -9,7 +9,7 @@ export advancedconnect,
        Connection, Metadata, conn, Connections, 
        disconnect, listdrivers, listdsns
 
-import Base: arrayset, show, string
+import Base: show, string
 
 include("ODBC_Types.jl")
 include("ODBC_API.jl")

--- a/src/backend.jl
+++ b/src/backend.jl
@@ -127,47 +127,49 @@ ODBCClean(x::Array{SQLTimestamp,1},y,z)    = datetime(int64(x[y].year),int64(0 <
                                                     int64(x[y].hour),int64(x[y].minute),int64(x[y].second),int64(div(x[y].fraction,1000000)))
 
 function ODBCCopy!(dest,dsto,src,n,ind,nas)
-    unsafe_copy!(pointer(dest,dsto),pointer(src,1),n)
     for i = 1:n
         nas[i+dsto-1] = ind[i] < 0
+        dest[i+dsto-1] = src[i]
     end
 end
 function ODBCCopy!(dest::Array{UTF8String},dsto,src::Array{Uint8,2},n,ind,nas)
     for i = 1:n
         nas[i+dsto-1] = ind[i] < 0
-        arrayset(dest, utf8(bytestring(src[1:ind[i],i])), i+dsto-1)
+        dest[i+dsto-1] = utf8(bytestring(src[1:ind[i],i]))
     end
 end
 function ODBCCopy!(dest::Array{UTF16String},dsto,src::Array{Uint16,2},n,ind,nas)
     for i = 1:n
         nas[i+dsto-1] = ind[i] < 0
-        arrayset(dest, UTF16String(src[1:div(ind[i],2),i]), i+dsto-1)
+        dest[i+dsto-1] = UTF16String(src[1:div(ind[i],2),i])
     end
 end
 function ODBCCopy!(dest::Array{UTF8String},dsto,src::Array{Uint32},n,ind,nas)
     for i = 1:n
         nas[i+dsto-1] = ind[i] < 0
-        arrayset(dest, utf8(bytestring(convert(Array{Uint8},src[1:div(ind[i],4),i]))), i+dsto-1)
+        dest[i+dsto-1] = utf8(bytestring(convert(Array{Uint8},src[1:div(ind[i],4),i])))
     end
 end
 function ODBCCopy!{D<:Date}(dest::Array{D},dsto,src::Array{SQLDate},n,ind,nas)
     for i = 1:n
         nas[i+dsto-1] = ind[i] < 0
-        arrayset(dest, date(int64(src[i].year),
-            int64(0 < src[i].month < 13 ? src[i].month : 1),int64(src[i].day)), i+dsto-1)
+        dest[i+dsto-1] = date(int64(src[i].year),
+                              int64(0 < src[i].month < 13 ? src[i].month : 1),
+                              int64(src[i].day))
     end
 end
 function ODBCCopy!{D<:DateTime}(dest::Array{D},dsto,src::Array{SQLTimestamp},n,ind,nas)
     for i = 1:n
         nas[i+dsto-1] = ind[i] < 0
-        arrayset(dest, datetime(int64(src[i].year),int64(0 < src[i].month < 13 ? src[i].month : 1),
-            int64(src[i].day),int64(src[i].hour),int64(src[i].minute),int64(src[i].second),int64(div(src[i].fraction,1000000))),i+dsto-1)
+        dest[i+dsto-1] = datetime(int64(src[i].year),int64(0 < src[i].month < 13 ? src[i].month : 1),
+                                  int64(src[i].day),int64(src[i].hour),int64(src[i].minute),
+                                  int64(src[i].second),int64(div(src[i].fraction,1000000)))
     end
 end
 function ODBCCopy!(dest::Array{SQLTime},dsto,src::Array{SQLTime},n,ind,nas)
     for i = 1:n
         nas[i+dsto-1] = ind[i] < 0
-        arrayset(dest, src[i], i+dsto-1)
+        dest[i+dsto-1] = src[i]
     end
 end
 


### PR DESCRIPTION
When you're doing this much I/O, bounds checking and array assignment are completely trivial overhead, so having `@inbounds` annotations, direct calls to `arrayset`, and `unsafe_copy!` calls are not necessary. In general, you shouldn't use any of these these unless you've determined using profiling that something is actually a hotspot _and_ you can prove from the surrounding context that they cannot be incorrect unless something crazy happens. "Crazy" does not include the caller giving you incorrect bounds; crazy is more like the size of an array being changed out from under you in a simple loop – that is reasonable to assume won't happen.
