### PR TITLE
Work around a driver that report indcols incorrectly

### DIFF
--- a/src/Query.jl
+++ b/src/Query.jl
@@ -207,7 +207,7 @@ function cast!(::Type{Union{String, Missing}}, source, col)
     elsize = source.sizes[col] + 1
     inds = source.indcols[col]
     @inbounds for i in 1:len
-        ind = inds[i]
+        ind = min(inds[i]|>Int, elsize|>Int)
         length = bytes2codeunits(T, max(ind, 0))
         c[i] = ind == API.SQL_NULL_DATA ? missing : (length == 0 ? "" : String(transcode(UInt8, data[cur:(cur + length - 1)])))
         cur += elsize


### PR DESCRIPTION
I am using an SQL Server 2008 with ODBC Driver 17 for SQL Server from Microsoft.
It seems for varchar(200) columns it sets indcols to a value larger than 201, causing
a BoundsError. Use the lessor one of elsize and indcols to work around this.