### PR TITLE
Update Query.jl

### DIFF
--- a/src/Query.jl
+++ b/src/Query.jl
@@ -31,7 +31,7 @@ Base.eltype(q::Query{rows, NT}) where {rows, NT} = NT
 end
 
 function Base.iterate(q::Query{rows, NT}, st=1) where {rows, NT}
-    (st > q.rowsfetched[] && q.status[] != API.SQL_SUCCESS && q.status[] != API.SQL_SUCCESS_WITH_INFO) && return nothing
+    ((st > q.rowsfetched[] && q.status[] != API.SQL_SUCCESS && q.status[] != API.SQL_SUCCESS_WITH_INFO) || q.status[] == API.SQL_NO_DATA) && return nothing
     nt = generate_namedtuple(NT, q, st)
     if st == q.rowsfetched[]
         q.status[] = API.SQLFetchScroll(q.stmt, API.SQL_FETCH_NEXT, 0)


### PR DESCRIPTION
Hello, sorry for my bad english.

On Windows 7 / office 2016, the ODBC drivers for access keep the q.rowsfetched[] at 1 when we are at the end of the Database table. Only the q.status[] is updated to 100 aka SQL_NO_DATA. This cause the iterate function to return the last line of the table for each call instead of nothing, causing an infinite loop.

Here is my debug trace :
Debug line 37 is a primary key on the readed table

+ @ ODBC C:\Users\BC5234\.julia\packages\ODBC\KFiOK\src\Query.jl:34
+ Warning: iterate...
+ @ ODBC C:\Users\BC5234\.julia\packages\ODBC\KFiOK\src\Query.jl:37
+ Warning: Union{Missing, String}["120005459237"]
+ @ ODBC C:\Users\BC5234\.julia\packages\ODBC\KFiOK\src\Query.jl:41
+ Warning: dbg st=1  q.rowsfetched[]=1  q.status[]=0
+ @ ODBC C:\Users\BC5234\.julia\packages\ODBC\KFiOK\src\Query.jl:34
+ Warning: iterate...
+ @ ODBC C:\Users\BC5234\.julia\packages\ODBC\KFiOK\src\Query.jl:37
+ Warning: Union{Missing, String}["220004383869"]
+ @ ODBC C:\Users\BC5234\.julia\packages\ODBC\KFiOK\src\Query.jl:41
+ Warning: dbg st=1  q.rowsfetched[]=1  q.status[]=0
+ @ ODBC C:\Users\BC5234\.julia\packages\ODBC\KFiOK\src\Query.jl:34
+ Warning: iterate...
+ @ ODBC C:\Users\BC5234\.julia\packages\ODBC\KFiOK\src\Query.jl:37
+ Warning: Union{Missing, String}["040012397688"]
+ @ ODBC C:\Users\BC5234\.julia\packages\ODBC\KFiOK\src\Query.jl:41

************************** The last line **********************************

+ Warning: dbg st=1  q.rowsfetched[]=1  q.status[]=0
+ @ ODBC C:\Users\BC5234\.julia\packages\ODBC\KFiOK\src\Query.jl:34
+ Warning: iterate...
+ @ ODBC C:\Users\BC5234\.julia\packages\ODBC\KFiOK\src\Query.jl:37
+ Warning: Union{Missing, String}["040012397688"]
+ @ ODBC C:\Users\BC5234\.julia\packages\ODBC\KFiOK\src\Query.jl:41

***************** SQL_NO_DATA and q.rowsfetched[]=1   ********************

+ Warning: dbg st=1  q.rowsfetched[]=1  q.status[]=100
+ @ ODBC C:\Users\BC5234\.julia\packages\ODBC\KFiOK\src\Query.jl:34
+ Warning: iterate...
+ @ ODBC C:\Users\BC5234\.julia\packages\ODBC\KFiOK\src\Query.jl:37
+ Warning: Union{Missing, String}["040012397688"]
+ @ ODBC C:\Users\BC5234\.julia\packages\ODBC\KFiOK\src\Query.jl:41

************************* and so on, traped on infinite loop **********************

+ Warning: dbg st=1  q.rowsfetched[]=1  q.status[]=100
+ @ ODBC C:\Users\BC5234\.julia\packages\ODBC\KFiOK\src\Query.jl:34
+ Warning: iterate...



