### PR TITLE
Do not copy more than buffer size in API.Long cast

### DIFF
--- a/src/Query.jl
+++ b/src/Query.jl
@@ -247,7 +247,7 @@ function cast!(::Type{API.Long{Union{T, Missing}}}, source, col) where {T}
     res = API.SQLGetData(stmt, col, source.ctypes[col], pointer(buf), sizeof(buf), ind)
     isnull = ind[] == API.SQL_NULL_DATA
     while !isnull
-        len = ind[]
+        len = min(LONG_DATA_BUFFER_SIZE,ind[])
         oldlen = length(data)
         resize!(data, oldlen + bytes2codeunits(eT, len))
         ccall(:memcpy, Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t), pointer(data, oldlen + 1), pointer(buf), len)


### PR DESCRIPTION
If the size of the returned value is more than `LONG_DATA_BUFFER_SIZE`, then we would be copying garbage using`memcpy`. Hence, it is necessary to ensure that only `LONG_DATA_BUFFER_SIZE` bytes are being copied in each loop iteration.

Closes #224