### PR TITLE
Allow a fix for #249

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -234,10 +234,15 @@ function getconnectattr(dbc, attr)
     return ret[]
 end
 
+const SQL_BATCH_SUPPORT = 121
 const SQL_BS_SELECT_EXPLICIT = 0x00000001
 const SQL_BS_ROW_COUNT_EXPLICIT = 0x00000002
 const SQL_BS_SELECT_PROC = 0x00000004
 const SQL_BS_ROW_COUNT_PROC = 0x00000008
+
+const SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES2 = 147
+const SQL_CA2_CRC_EXACT = 0x00001000
+const SQL_CA2_CRC_APPROXIMATE = 0x00002000
 
 function getinfosqluinteger(dbc::Handle, type=121)
     ref = Ref{SQLUINTEGER}()

--- a/src/dbinterface.jl
+++ b/src/dbinterface.jl
@@ -106,7 +106,7 @@ Supported keyword arguments include:
   * `normalizenames::Bool`: normalize column names to valid Julia identifiers; this can be convenient when working with the results in, for example, a `DataFrame` where you can access columns like `df.col1`
   * `debug::Bool`: for printing additional debug information during the query/result process.
 """
-function DBInterface.execute(stmt::Statement, params=(); debug::Bool=true, kw...)
+function DBInterface.execute(stmt::Statement, params=(); debug::Bool=false, kw...)
     API.freestmt(stmt.stmt)
     clear!(stmt.dsn)
     paramcheck(stmt, params)
@@ -137,7 +137,7 @@ This is an alternative execution path to `DBInterface.execute` with a prepared s
 This method is faster/less overhead for one-time executions, but prepared statements will
 have more benefit for repeated executions (even with different parameters).
 """
-function DBInterface.execute(conn::Connection, sql::AbstractString, params=(); debug::Bool=true, kw...)
+function DBInterface.execute(conn::Connection, sql::AbstractString, params=(); debug::Bool=false, kw...)
     clear!(conn)
     stmt = API.Handle(API.SQL_HANDLE_STMT, API.getptr(conn.dbc))
     bindings = bindparams(stmt, params, nothing)

--- a/src/dbinterface.jl
+++ b/src/dbinterface.jl
@@ -92,14 +92,19 @@ end
 @noinline paramcheck(stmt, params) = length(params) == stmt.nparams || error("stmt requires $(stmt.nparams) params, only $(length(params)) provided")
 
 """
-    DBInterface.execute(stmt, params=(); kw...) -> ODBC.Cursor
+    DBInterface.execute(stmt, params=(); iterate_rows::Bool=false, ignore_driver_row_count::Bool=false, normalizenames::Bool=false, debug::Bool=false) -> ODBC.Cursor
 
 Execute a prepare statement, binding any parameters beforehand. Returns a `Cursor`
 object, even if the statement is not resultset-producing (cursor will have zero rows and/or columns).
 The `Cursor` object satisfies the [Tables.jl](https://juliadata.github.io/Tables.jl/dev/)
 interface as a source, so any valid sink can be used for inspecting results (a list of integrations
-is maintained [here](https://github.com/JuliaData/Tables.jl/blob/master/INTEGRATIONS.md)). Supported keyword arguments include `iterate_rows::Bool` for forcing row iteration of the 
-resultset, and `debug::Bool` for printing additional debug information during the query/result process.
+is maintained [here](https://github.com/JuliaData/Tables.jl/blob/master/INTEGRATIONS.md)).
+
+Supported keyword arguments include:
+  * `iterate_rows::Bool`: for forcing row iteration of the resultset
+  * `ignore_driver_row_count::Bool`: for ignoring the row count returned from the database driver; in some cases (Netezza), the driver may return an incorrect or "prefetched" number for the row count instead of the actual row count; this allows ignoring those numbers and fetching the resultset until truly exhausted
+  * `normalizenames::Bool`: normalize column names to valid Julia identifiers; this can be convenient when working with the results in, for example, a `DataFrame` where you can access columns like `df.col1`
+  * `debug::Bool`: for printing additional debug information during the query/result process.
 """
 function DBInterface.execute(stmt::Statement, params=(); debug::Bool=true, kw...)
     API.freestmt(stmt.stmt)
@@ -114,14 +119,19 @@ function DBInterface.execute(stmt::Statement, params=(); debug::Bool=true, kw...
 end
 
 """
-    DBInterface.execute(conn, sql, params=(); kw...) -> ODBC.Cursor
+    DBInterface.execute(conn, sql, params=(); iterate_rows::Bool=false, ignore_driver_row_count::Bool=false, normalizenames::Bool=false, debug::Bool=false) -> ODBC.Cursor
 
 Send a query directly to connection for execution. Returns a `Cursor`
 object, even if the statement is not resultset-producing (cursor will have zero rows and/or columns).
 The `Cursor` object satisfies the [Tables.jl](https://juliadata.github.io/Tables.jl/dev/)
 interface as a source, so any valid sink can be used for inspecting results (a list of integrations
-is maintained [here](https://github.com/JuliaData/Tables.jl/blob/master/INTEGRATIONS.md)). Supported keyword arguments include `iterate_rows::Bool` for forcing row iteration of the 
-resultset, and `debug::Bool` for printing additional debug information during the query/result process.
+is maintained [here](https://github.com/JuliaData/Tables.jl/blob/master/INTEGRATIONS.md)).
+
+Supported keyword arguments include:
+  * `iterate_rows::Bool`: for forcing row iteration of the resultset
+  * `ignore_driver_row_count::Bool`: for ignoring the row count returned from the database driver; in some cases (Netezza), the driver may return an incorrect or "prefetched" number for the row count instead of the actual row count; this allows ignoring those numbers and fetching the resultset until truly exhausted
+  * `normalizenames::Bool`: normalize column names to valid Julia identifiers; this can be convenient when working with the results in, for example, a `DataFrame` where you can access columns like `df.col1`
+  * `debug::Bool`: for printing additional debug information during the query/result process.
 
 This is an alternative execution path to `DBInterface.execute` with a prepared statement.
 This method is faster/less overhead for one-time executions, but prepared statements will

--- a/src/dbinterface.jl
+++ b/src/dbinterface.jl
@@ -152,7 +152,7 @@ mutable struct Cursor{columnar, knownlength}
 end
 
 # takes a recently executed statement handle and handles any produced resultsets
-function Cursor(stmt; iterate_rows::Bool=false, normalizenames::Bool=false, debug::Bool=false)
+function Cursor(stmt; iterate_rows::Bool=false, ignore_driver_row_count::Bool=false, normalizenames::Bool=false, debug::Bool=false)
     rows = API.numrows(stmt)
     cols = API.numcols(stmt)
     debug && println("rows = $rows, cols = $cols")
@@ -187,10 +187,10 @@ function Cursor(stmt; iterate_rows::Bool=false, normalizenames::Bool=false, debu
     end
     metadata = [["column name", names...] ["column type", types...] ["sql type", map(x->API.SQL_TYPES[x], sqltypes)...] ["c type", map(x->API.C_TYPES[x], ctypes)...] ["sizes", map(Int, columnsizes)...] ["nullable", map(x->x != API.SQL_NO_NULLS, nullables)...] ["long data", longtexts...]]
     columnar = knownlength = true
-    if any(longtexts) || rows <= 0 || iterate_rows
+    if any(longtexts) || rows <= 0 || iterate_rows || ignore_driver_row_count
         rowset = 1
         columnar = false
-        knownlength = rows > 0
+        knownlength = rows > 0 && !ignore_driver_row_count
     else
         rowset = rows
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -192,7 +192,7 @@ DBInterface.execute(stmt, [missing, missing, missing, missing, missing, missing,
 DBInterface.close!(stmt)
 
 stmt = DBInterface.prepare(conn, "select * from Employee")
-res = DBInterface.execute(stmt) |> columntable
+res = DBInterface.execute(stmt; ignore_driver_row_count=true) |> columntable
 DBInterface.close!(stmt)
 for i = 1:length(expected)
     if i != 11 && i != 1


### PR DESCRIPTION
From some research discovered
[here](http://datamining.togaware.com/survivor/Database_Connection.html)
and in the Netezza ODBC documentation
[here](https://www.ibm.com/support/knowledgecenter/SSULQD_7.1.0/com.ibm.nz.datacon.doc/r_datacon_odbc_driver_setup_win.html),
the Netezza ODBC driver, by default, has a 'Prefetch Count' setting,
defaulting to 256, that limits the # of rows that will return for a
resultset. It's unclear whether you can set this number to -1 or some
really large integer # (4 trillion or so) and if that would work (or try
to consume that much memory by pre-allocating?).

In any case, RODBC has a setting `believeNRows`, so we introduce a
similar (though IMO better named) keyword argument
`ignore_driver_row_count`, which, when set to `true`, will force the
result handling code to iterate rows with no known length, which is the
setting we want when we're unable to pre-allocate full columns.