### PR TITLE
Don't run mkdir if dir exists (or it will error)

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,5 @@
 dir = joinpath(@__DIR__, "../config")
-mkdir(dir)
+isdir(dir) || mkdir(dir)
 open(joinpath(dir, "odbc.ini"), "w") do io
     write(io, "[ODBC Data Sources]\n\n[ODBC]\nTrace=0\nTraceFile=stderr\n")
 end


### PR DESCRIPTION
I deleted my config files but not the config directory and got an error when running `]build`:

```
┌ Error: Error building `ODBC`:
│ ERROR: LoadError: IOError: mkdir: file already exists (EEXIST)
│ Stacktrace:
│  [1] uv_error at ./libuv.jl:97 [inlined]
│  [2] mkdir(::String; mode::UInt16) at ./file.jl:177
│  [3] mkdir(::String) at ./file.jl:170
│  [4] top-level scope at /Users/ericdavies/repos/ODBC.jl/deps/build.jl:2
│  [5] include(::String) at ./client.jl:439
│  [6] top-level scope at none:5
│ in expression starting at /Users/ericdavies/repos/ODBC.jl/deps/build.jl:2
```

This fixes that