### PR TITLE
ODBC info messages changed from warn to info

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -109,7 +109,7 @@ macro checksuccess(h, expr)
     esc(quote
         ret = $expr
         if ret == SQL_SUCCESS_WITH_INFO
-            @warn diagnostics($h)
+            @info diagnostics($h)
         elseif ret == SQL_ERROR || ret == SQL_INVALID_HANDLE
             error(diagnostics($h))
         end


### PR DESCRIPTION
This was routinely emitting rather benign-looking messages for me, so I changed it to `@info`.