### PR TITLE
further demote diagnostics log output to debug

### DIFF
--- a/src/API.jl
+++ b/src/API.jl
@@ -109,7 +109,7 @@ macro checksuccess(h, expr)
     esc(quote
         ret = $expr
         if ret == SQL_SUCCESS_WITH_INFO
-            @info diagnostics($h)
+            @debug diagnostics($h)
         elseif ret == SQL_ERROR || ret == SQL_INVALID_HANDLE
             error(diagnostics($h))
         end


### PR DESCRIPTION
I've been using this a good while now, and this never stopped driving me nuts, and I think it's pretty safe to say that the kind of output it gives usually does not get printed by other database interfaces.  In particular, it would spit output at me every time `ODBC.Connection` was called, which was getting pretty annoying.

I'm pretty sure pretty much everyone will be happier with these messages on `@debug` rather than `@info`.