### PR TITLE
Don't index past the end of our buffer

### DIFF
--- a/src/dbinterface.jl
+++ b/src/dbinterface.jl
@@ -352,7 +352,7 @@ function Tables.getcolumn(x::Row, ::Type{T}, i::Int, nm::Symbol) where {T}
         return missing
     elseif b.valuetype == API.SQL_C_CHAR || b.valuetype == API.SQL_C_WCHAR || b.valuetype == API.SQL_C_BINARY
         data = b.value.buffer::Vector{UInt8}
-        bytes = data[1:b.totallen]
+        bytes = data[1:min(length(data), b.totallen)]
         return jlcast(Base.nonmissingtype(T), bytes)
     elseif b.valuetype == API.SQL_C_TYPE_DATE || b.valuetype == API.SQL_C_TYPE_TIME || b.valuetype == API.SQL_C_TYPE_TIMESTAMP
         return specialize(x -> Base.nonmissingtype(T)(x[1]), b.value.buffer)


### PR DESCRIPTION
Attempt at fixing #306. It's a little unclear what's going on here; for
some reason, our length indicator is coming back with a value of 12,
even though the column size told us it wouldn't be more than 11 bytes. I
think we're correctly incrementing the columnsize of Dec64 by 1 because
the C storage is SQL_C_CHAR, but yeah, I don't understand why it's
coming back w/ more bytes that we're expecting.

My main worry with this fix is if we're actually missing a byte that
should be included in the final Dec64 number, but this should at least
allow us to materialize the full result.