### PR TITLE
missing interface element

### DIFF
--- a/src/dbinterface.jl
+++ b/src/dbinterface.jl
@@ -114,6 +114,13 @@ mutable struct Statement <: DBInterface.Statement
 end
 
 """
+    DBInterface.getconnection(stmt)
+
+Return the connection for the given statement. Part of the required interface.
+"""
+DBInterface.getconnection(stmt::Statement) = stmt.dsn
+
+"""
     DBInterface.close!(stmt)
 
 Close a prepared statement. Further parameter binding or execution will not be valid.


### PR DESCRIPTION
getconnection is missing, which is part of the DBInterface

used by executemany, missing in ODBC

see open issue on DBInterface

https://github.com/JuliaDatabases/DBInterface.jl/issues/43