### PR TITLE
converting null-terminated numeric strings

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -337,7 +337,7 @@ bindcol(stmt, i, b::Binding) = API.SQLBindCol(API.getptr(stmt), i,
     b.valuetype, pointer(b.value), b.bufferlength, b.strlen_or_indptr)
 
 function jlcast(::Type{T}, bytes) where {T <: DecFP.DecimalFloatingPoint}
-    x = String(bytes)
+    x = rstrip(String(bytes), '\0')
     parse(T, x)
 end
 jlcast(::Type{Vector{UInt8}}, bytes) = bytes

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -35,8 +35,8 @@ DBInterface.close!(conn)
 conn = DBInterface.connect(ODBC.Connection, "Driver={ODBC_Test_MariaDB};SERVER=127.0.0.1;PLUGIN_DIR=$PLUGIN_DIR;Option=67108864;CHARSET=utf8mb4;USER=root")
 
 DBInterface.execute(conn, "DROP DATABASE if exists mysqltest")
-DBInterface.execute(conn, "CREATE DATABASE mysqltest")
 DBInterface.execute(conn, "CREATE DATABASE mysqltest CHARACTER SET = 'utf8mb3' COLLATE = 'utf8mb3_general_ci'")
+DBInterface.execute(conn, "use mysqltest")
 DBInterface.execute(conn, """CREATE TABLE Employee
                  (
                      ID INT NOT NULL AUTO_INCREMENT,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,7 +36,7 @@ conn = DBInterface.connect(ODBC.Connection, "Driver={ODBC_Test_MariaDB};SERVER=1
 
 DBInterface.execute(conn, "DROP DATABASE if exists mysqltest")
 DBInterface.execute(conn, "CREATE DATABASE mysqltest")
-DBInterface.execute(conn, "use mysqltest")
+DBInterface.execute(conn, "CREATE DATABASE mysqltest CHARACTER SET = 'utf8mb3' COLLATE = 'utf8mb3_general_ci'")
 DBInterface.execute(conn, """CREATE TABLE Employee
                  (
                      ID INT NOT NULL AUTO_INCREMENT,


### PR DESCRIPTION
Currently, converting a query result to a dataframe of results in an error when the numeric data contains a null-terminated string.
The origin is that the parsing routine of DecFP, which is called by jlcast errors out.

The proposed PR makes the conversion more robust