### PR TITLE
Handle runtime error on Base.iterate

### DIFF
--- a/src/consts.jl
+++ b/src/consts.jl
@@ -282,7 +282,6 @@ const C_TYPES = Dict(
 # success codes
 const SQL_SUCCESS           = Int16(0)
 const SQL_SUCCESS_WITH_INFO = Int16(1)
-const SQL_STILL_EXECUTING   = Int16(2)
 
 # error codes
 const SQL_ERROR             = Int16(-1)
@@ -295,7 +294,10 @@ const SQL_NO_DATA           = Int16(100)
 
 const RETURN_VALUES = Dict(SQL_ERROR   => "SQL_ERROR",
                            SQL_NO_DATA => "SQL_NO_DATA",
-                           SQL_INVALID_HANDLE  => "SQL_INVALID_HANDLE",
-                           SQL_STILL_EXECUTING => "SQL_STILL_EXECUTING")
+                           SQL_SUCCESS => "SQL_SUCCESS",
+                           SQL_NTS     => "SQL_NTS",
+                           SQL_STILL_EXECUTING   => "SQL_STILL_EXECUTING",
+                           SQL_INVALID_HANDLE    => "SQL_INVALID_HANDLE",
+                           SQL_SUCCESS_WITH_INFO => "SQL_SUCCESS_WITH_INFO")
 
 const SQL_NO_NULLS = Int16(0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -85,6 +85,12 @@ expected = (
   Senior     = Union{Missing, Bool}[true, true, false, true],
 )
 
+
+# Validate that iteration of results throws runtime Error on DivisionByZero
+@test_throws ErrorException DBInterface.execute(
+    conn, "SELECT a, b, a/b FROM (VALUES (2,1),(1,0),(2,1)) AS t(a,b)"
+) |> columntable
+
 cursor = DBInterface.execute(conn, "select * from Employee")
 @test eltype(cursor) == ODBC.Row
 @test Tables.istable(cursor)


### PR DESCRIPTION
`API.SQLFetchScroll(API.getptr(x.stmt), API.SQL_FETCH_NEXT, 0)` may return an error after only some of the results have been loaded. In the current implementation the error is ignored and iterate just stops the iteration, returning all the rows up to this point.

With this edit, the iteration will either warn the user or throw an error, consistent with the behaviour of `@checkresult`.

Should fix https://github.com/JuliaDatabases/ODBC.jl/issues/352

In a weird sense this is technically a breaking change - as queries that returned early with a subset of results will now raise an error. In the grand scheme of things though I think tihs is a good change.