### PR TITLE
support SecretBuffer for passwords/extraauth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,45 +19,49 @@ jobs:
           - ubuntu-latest
         arch:
           - x64
+    env:
+      MARIADB_CONNECTOR_VERSION: "3.1.20"
+      MARIADB_CONNECTOR_FILE: "mariadb-connector-odbc-3.1.20-ubuntu-focal-amd64.tar.gz"
     steps:
       - uses: actions/checkout@v4
-      # 1. Cache the downloaded archive to avoid scraping the website on every single commit
-      - name: Cache MariaDB ODBC Driver Archive
-        id: cache-odbc
+      # 1. Cache the downloaded archive using the proper naming convention
+      - name: Cache MariaDB Connector Archive
+        id: cache-mariadb-connector
         uses: actions/cache@v4
         with:
-          path: mariadb-connector-odbc-3.1.20-ubuntu-focal-amd64.tar.gz
-          key: odbc-3.1.20-ubuntu-focal
-      # 2. Use your session-aware scraping logic only if the file is missing from cache
-      - name: Download MariaDB ODBC Driver
-        if: steps.cache-odbc.outputs.cache-hit != 'true'
+          path: ${{ env.MARIADB_CONNECTOR_FILE }}
+          key: mariadb-connector-${{ env.MARIADB_CONNECTOR_VERSION }}-ubuntu-focal
+      # 2. Download step with dynamic URL and filename handling
+      - name: Download MariaDB Connector
+        if: steps.cache-mariadb-connector.outputs.cache-hit != 'true'
         shell: bash
         run: |
           set -e
-          echo "Driver archive not in cache. Fetching from MariaDB DLM..."
+          BASE_URL="https://dlm.mariadb.com/browse/odbc_connector/${{ env.MARIADB_CONNECTOR_VERSION }}/"
+          echo "Fetching from web page: $BASE_URL"
           
           # Access download page and persistently save session cookies
-          HTML_PAGE=$(curl -sL --cookie-jar cookies.txt "https://mariadb.com")
+          HTML_PAGE=$(curl -sL --cookie-jar cookies.txt "$BASE_URL")
           
-          # Match the exact file name and isolate the dynamic URL
-          URL=$(echo "$HTML_PAGE" | grep -oP "href=\"\K[^\"]*mariadb-connector-odbc-3\.1\.20-ubuntu-focal-amd64\.tar\.gz")
+          # Match the exact file name using the correct variable name
+          URL=$(echo "$HTML_PAGE" | grep -oP "href=\"\K[^\"]*${{ env.MARIADB_CONNECTOR_FILE }}")
           
           if [ -z "$URL" ]; then
-              echo "Error: Could not extract driver URL from the web page."
+              echo "Error: Could not extract download URL for ${{ env.MARIADB_CONNECTOR_FILE }} from $BASE_URL"
               rm -f cookies.txt
               exit 1
           fi
           
-          # Execute the download using the required session cookies
-          curl -fSL --cookie cookies.txt -o "mariadb-connector-odbc-3.1.20-ubuntu-focal-amd64.tar.gz" "$URL"
+          # Execute the download using the cookies and target file environment variable
+          curl -fSL --cookie cookies.txt -o "${{ env.MARIADB_CONNECTOR_FILE }}" "$URL"
           
           # Clean up temporary cookie storage
           rm -f cookies.txt
-      # 3. Create target folder and extract the driver archive (runs always)
-      - name: Extract MariaDB ODBC Driver
+      # 3. Create target folder and extract the connector archive (runs always)
+      - name: Extract MariaDB Connector
         run: |
           mkdir -p /home/runner/mariadb64
-          tar xfz mariadb-connector-odbc-3.1.20-ubuntu-focal-amd64.tar.gz -C /home/runner/mariadb64
+          tar xfz ${{ env.MARIADB_CONNECTOR_FILE }} -C /home/runner/mariadb64
       - uses: getong/mariadb-action@v1.1
         with:
           host port: 3306 # Optional, default value is 3306. The port of host

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,41 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v4
-      - run: |
-          curl -O https://mariadb.org/mariadb-connector-odbc-3.1.20-ubuntu-focal-amd64.tar.gz
+      # 1. Cache the downloaded archive to avoid scraping the website on every single commit
+      - name: Cache MariaDB ODBC Driver Archive
+        id: cache-odbc
+        uses: actions/cache@v4
+        with:
+          path: mariadb-connector-odbc-3.1.20-ubuntu-focal-amd64.tar.gz
+          key: odbc-3.1.20-ubuntu-focal
+      # 2. Use your session-aware scraping logic only if the file is missing from cache
+      - name: Download MariaDB ODBC Driver
+        if: steps.cache-odbc.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -e
+          echo "Driver archive not in cache. Fetching from MariaDB DLM..."
+          
+          # Access download page and persistently save session cookies
+          HTML_PAGE=$(curl -sL --cookie-jar cookies.txt "https://mariadb.com")
+          
+          # Match the exact file name and isolate the dynamic URL
+          URL=$(echo "$HTML_PAGE" | grep -oP "href=\"\K[^\"]*mariadb-connector-odbc-3\.1\.20-ubuntu-focal-amd64\.tar\.gz")
+          
+          if [ -z "$URL" ]; then
+              echo "Error: Could not extract driver URL from the web page."
+              rm -f cookies.txt
+              exit 1
+          fi
+          
+          # Execute the download using the required session cookies
+          curl -fSL --cookie cookies.txt -o "mariadb-connector-odbc-3.1.20-ubuntu-focal-amd64.tar.gz" "$URL"
+          
+          # Clean up temporary cookie storage
+          rm -f cookies.txt
+      # 3. Create target folder and extract the driver archive (runs always)
+      - name: Extract MariaDB ODBC Driver
+        run: |
           mkdir -p /home/runner/mariadb64
           tar xfz mariadb-connector-odbc-3.1.20-ubuntu-focal-amd64.tar.gz -C /home/runner/mariadb64
       - uses: getong/mariadb-action@v1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: |
-          curl -O https://downloads.mariadb.com/Connectors/odbc/connector-odbc-3.1.20/mariadb-connector-odbc-3.1.20-ubuntu-focal-amd64.tar.gz
+          curl -O https://mariadb.org/mariadb-connector-odbc-3.1.20-ubuntu-focal-amd64.tar.gz
           mkdir -p /home/runner/mariadb64
           tar xfz mariadb-connector-odbc-3.1.20-ubuntu-focal-amd64.tar.gz -C /home/runner/mariadb64
       - uses: getong/mariadb-action@v1.1

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ conn = ODBC.Connection("DSN=mydb"; user="alice", password="secret123")
 ```
 
 **Why SecretBuffer?**
-- Credentials are automatically zeroed in memory after use
+- Minimizes the lifetime of credentials in memory
 - Reduces exposure to memory dumps, core dumps, and debugging tools
 - Required for security compliance (PCI-DSS, HIPAA, SOC2)
 - Protects against credential leakage in long-running processes

--- a/README.md
+++ b/README.md
@@ -16,6 +16,51 @@ The package is registered in the `General` registry and so can be installed with
 julia> using Pkg; Pkg.add("ODBC")
 ```
 
+## Quick Start
+
+```julia
+using ODBC, DataFrames
+
+# For production: Use getpass() to securely prompt for credentials
+pwd = Base.getpass("Enter password")
+conn = ODBC.Connection("DSN=mydb"; user="admin", password=pwd)
+# Credentials are automatically shredded from memory after connection
+
+# Execute queries
+result = DBInterface.execute(conn, "SELECT * FROM users") |> DataFrame
+```
+
+## Security: Use SecretBuffer for Credentials
+
+**Important for production systems**: Regular Julia `String` objects cannot be securely erased from memory. For sensitive credentials, use `Base.SecretBuffer`:
+
+```julia
+# RECOMMENDED: Use getpass() for interactive password input (won't echo to screen)
+pwd = Base.getpass("Enter password")
+conn = ODBC.Connection("DSN=mydb"; user="alice", password=pwd)
+
+# For non-interactive contexts (environment variables)
+pwd = Base.SecretBuffer(ENV["DB_PASSWORD"])
+conn = ODBC.Connection("DSN=mydb"; user="alice", password=pwd)
+
+# For Docker secrets or file-based credentials
+pwd = open("/run/secrets/db_password") do io
+    sb = Base.SecretBuffer()
+    write(sb, io)
+    seekstart(sb)
+end
+conn = ODBC.Connection("DSN=mydb"; user="alice", password=pwd)
+
+# AVOID: Plain strings (stay in memory until garbage collected)
+conn = ODBC.Connection("DSN=mydb"; user="alice", password="secret123")
+```
+
+**Why SecretBuffer?**
+- Credentials are automatically zeroed in memory after use
+- Reduces exposure to memory dumps, core dumps, and debugging tools
+- Required for security compliance (PCI-DSS, HIPAA, SOC2)
+- Protects against credential leakage in long-running processes
+
 ## Documentation
 
 - [**STABLE**][docs-stable-url] &mdash; **most recently tagged version of the documentation.**

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -32,6 +32,46 @@ Once a driver or two are installed (viewable by calling `ODBC.drivers()`), you c
 
 In setting up a DSN, you can specify all the configuration options once, then connect by just calling `ODBC.Connection("dsn name")` or `DBInterface.execute(ODBC.Connection, "dsn name")`, optionally passing a username and password as the 2nd and 3rd arguments. Alternatively, crafting and connecting via a fully specified connection string can mean less config-file dependency.
 
+#### Secure Credential Handling
+
+**Security Best Practice**: For production systems handling sensitive data, use `Base.SecretBuffer` instead of plain strings for credentials:
+
+```julia
+# RECOMMENDED: Use getpass() for interactive password (won't echo to screen)
+pwd = Base.getpass("Enter password")
+conn = ODBC.Connection("DSN=mydb"; user="admin", password=pwd)
+# pwd is automatically zeroed - no manual cleanup needed!
+
+# AVOID: Plain strings remain in memory until garbage collected
+conn = ODBC.Connection("DSN=mydb"; user="admin", password="plaintext")
+```
+
+**Why SecretBuffer?**
+- Regular `String` objects are immutable and cannot be zeroed
+- Credentials in strings persist in memory, exposing them to memory dumps and debugging tools
+- `SecretBuffer` automatically shreds (zeros) memory after use
+- Essential for compliance with security standards (PCI-DSS, HIPAA, SOC2)
+
+**Common patterns:**
+
+```julia
+# Interactive password prompt (recommended - doesn't echo password)
+pwd = Base.getpass("Enter database password")
+conn = ODBC.Connection("DSN=mydb"; user="admin", password=pwd)
+
+# From environment variables (for non-interactive contexts)
+pwd = Base.SecretBuffer(ENV["DB_PASSWORD"])
+conn = ODBC.Connection("DSN=mydb"; user="admin", password=pwd)
+
+# All credentials secure
+usr = Base.SecretBuffer("admin")
+pwd = Base.getpass("Enter password")
+token = Base.SecretBuffer("AuthToken=xyz123")
+conn = ODBC.Connection("DSN=mydb"; user=usr, password=pwd, extraauth=token)
+```
+
+**Important**: Never put credentials directly in the DSN string (e.g., `"DSN=mydb;UID=user;PWD=pass"`) as the DSN is stored and displayed by the `Connection` object. Always use keyword arguments (`user=`, `password=`, `extraauth=`) for credentials.
+
 Note that connecting will use the currently "set" ODBC driver manager, which by default is iODBC on OSX, unixODBC on Linux, and
 the system driver manager on Windows. If you experience cryptic connection errors, it's probably worth checking with your ODBC
 driver documentation to see if it requires a specific driver manager. For example, Microsoft-provided ODBC driver for SQL Server
@@ -125,7 +165,6 @@ using DataFrames
 
 host = "trino-adhoc.my-company.net"
 port = "443"
-TRINO_CREDS = Dict("user" => ENV["TRINO_USER"], "password"=> ENV["TRINO_PASSWORD"])
 drivername = "trino"
 driverpath = "/Library/starburst/starburstodbc/lib/libstarburstodbc_sb64-universal.dylib"
 connection_string = "Driver=$(drivername);Host=$(host);Port=$(port);AuthenticationType=LDAP Authentication"
@@ -139,7 +178,10 @@ ODBC.drivers()
     # Dict{String, String} with 1 entry:
     # "trino" => "Installed"
 
-conn = ODBC.Connection(connection_string, TRINO_CREDS["user"], TRINO_CREDS["password"])
+# Use SecretBuffer for secure credential handling (recommended for production)
+usr = Base.SecretBuffer(ENV["TRINO_USER"])
+pwd = Base.SecretBuffer(ENV["TRINO_PASSWORD"])
+conn = ODBC.Connection(connection_string; user=usr, password=pwd)
 
 df = DBInterface.execute(conn, "show catalogs;") |> DataFrame;
 df = DBInterface.execute(conn, "select current_date as today;") |> DataFrame

--- a/src/API.jl
+++ b/src/API.jl
@@ -335,30 +335,68 @@ const SQL_DRIVER_COMPLETE_REQUIRED = UInt16(3)
 const SQL_DRIVER_NOPROMPT = UInt16(0)
 const SQL_DRIVER_PROMPT = UInt16(2)
 
-function SQLDriverConnect(dbc,connstr)
+function SQLDriverConnect(dbc, connstr::Union{AbstractString, Base.SecretBuffer})
     # need to call SQLDriverConnectW to ensure our application gets labelled "unicode"
     # and subsequent library calls behave properly
-    c = transcode(sqlwcharsize(), connstr)
-    # push!(c, sqlwcharsize()(0))
+
+    # Extract bytes and transcode to wide chars for unicode call
+    bytes = if connstr isa Base.SecretBuffer
+        # Read bytes from SecretBuffer, shred immediately
+        b = read(seekstart(connstr))
+        Base.shred!(connstr)
+        b
+    else
+        Vector{UInt8}(connstr)
+    end
+    wchars = transcode(sqlwcharsize(), bytes)
+
+    # Try unicode version first
     ret = @odbc(:SQLDriverConnectW,
         (Ptr{Cvoid},Ptr{Cvoid},Ptr{SQLWCHAR},SQLSMALLINT,Ptr{SQLCHAR},SQLSMALLINT,Ptr{SQLSMALLINT},SQLUSMALLINT),
-        getptr(dbc),C_NULL,c,length(c),C_NULL,0,C_NULL,SQL_DRIVER_NOPROMPT)
+        getptr(dbc),C_NULL,wchars,length(wchars),C_NULL,0,C_NULL,SQL_DRIVER_NOPROMPT)
+
     if ret == SQL_ERROR
         # @warn diagnostics(dbc)
+        # Fallback to non-unicode version using the original bytes
         ret = @odbc(:SQLDriverConnect,
             (Ptr{Cvoid},Ptr{Cvoid},Ptr{SQLCHAR},SQLSMALLINT,Ptr{SQLCHAR},SQLSMALLINT,Ptr{SQLSMALLINT},SQLUSMALLINT),
-            getptr(dbc),C_NULL,connstr,SQL_NTS,C_NULL,0,C_NULL,SQL_DRIVER_NOPROMPT)
+            getptr(dbc),C_NULL,bytes,length(bytes),C_NULL,0,C_NULL,SQL_DRIVER_NOPROMPT)
     end
+
+    # SECURITY: Zero all sensitive buffers
+    fill!(wchars, 0)  # Zero the transcoded wide-char buffer
+    fill!(bytes, 0)   # Zero the byte buffer
+
     return ret
 end
 
-function driverconnect(connstr)
+function driverconnect(connstr::Union{AbstractString, Base.SecretBuffer})
     dbc = Handle(SQL_HANDLE_DBC, ODBC_ENV[])
     @checksuccess dbc SQLDriverConnect(dbc, connstr)
     return dbc
 end
 
-connect(dsn, extraauth) = driverconnect("$dsn;$extraauth")
+function connect(dsn::AbstractString, extraauth::Union{AbstractString, Base.SecretBuffer})
+    # Build the full connection string in a SecretBuffer to keep credentials secure
+    # Note: DSN typically doesn't contain credentials (e.g., "DSN=mydb" or driver info)
+    # All credentials are in extraauth (UID/PWD), which is what we're protecting
+    connbuf = Base.SecretBuffer()
+
+    # Add DSN part (non-sensitive - may be displayed in Connection.show)
+    write(connbuf, dsn)
+    write(connbuf, ";")
+
+    # Add extraauth part (contains sensitive credentials)
+    if extraauth isa Base.SecretBuffer
+        write(connbuf, read(seekstart(extraauth)))
+        Base.shred!(extraauth)
+    else
+        write(connbuf, extraauth)
+    end
+
+    # Pass SecretBuffer through the chain - will be shredded in SQLDriverConnect
+    driverconnect(connbuf)
+end
 
 function SQLDisconnect(dbc::Ptr{Cvoid})
     @odbc(:SQLDisconnect,

--- a/src/API.jl
+++ b/src/API.jl
@@ -388,8 +388,11 @@ function connect(dsn::AbstractString, extraauth::Union{AbstractString, Base.Secr
 
     # Add extraauth part (contains sensitive credentials)
     if extraauth isa Base.SecretBuffer
-        write(connbuf, read(seekstart(extraauth)))
-        Base.shred!(extraauth)
+        try
+            write(connbuf, seekstart(extraauth))
+        finally
+            Base.shred!(extraauth)
+        end
     else
         write(connbuf, extraauth)
     end

--- a/src/dbinterface.jl
+++ b/src/dbinterface.jl
@@ -34,6 +34,7 @@ function getextraauth(usr::Union{AbstractString, Base.SecretBuffer, Nothing},
         if usr isa Base.SecretBuffer
             seekstart(usr)
             write(buf, read(usr, usr.size))
+            Base.shred!(usr)
         else
             write(buf, usr)
         end
@@ -46,7 +47,8 @@ function getextraauth(usr::Union{AbstractString, Base.SecretBuffer, Nothing},
         write(buf, "PWD={")
         if pwd isa Base.SecretBuffer
             seekstart(pwd)
-            write(buf, read(pwd, pwd.size))
+            write(buf, read(pwd))
+            Base.shred!(pwd)
         else
             write(buf, pwd)
         end
@@ -59,6 +61,7 @@ function getextraauth(usr::Union{AbstractString, Base.SecretBuffer, Nothing},
         if extraauth isa Base.SecretBuffer
             seekstart(extraauth)
             write(buf, read(extraauth, extraauth.size))
+            Base.shred!(extraauth)
         else
             write(buf, extraauth)
         end

--- a/src/dbinterface.jl
+++ b/src/dbinterface.jl
@@ -31,13 +31,9 @@ function getextraauth(usr::Union{AbstractString, Base.SecretBuffer, Nothing},
     # Add username if provided
     if usr !== nothing
         write(buf, "UID={")
-        if usr isa Base.SecretBuffer
-            seekstart(usr)
-            write(buf, read(usr, usr.size))
-            Base.shred!(usr)
-        else
-            write(buf, usr)
-        end
+        usr isa Base.SecretBuffer && seekstart(usr)
+        write(buf, usr)
+        usr isa Base.SecretBuffer && Base.shred!(usr)
         write(buf, "}")
     end
 
@@ -45,26 +41,18 @@ function getextraauth(usr::Union{AbstractString, Base.SecretBuffer, Nothing},
     if pwd !== nothing
         usr !== nothing && write(buf, ";")
         write(buf, "PWD={")
-        if pwd isa Base.SecretBuffer
-            seekstart(pwd)
-            write(buf, read(pwd))
-            Base.shred!(pwd)
-        else
-            write(buf, pwd)
-        end
+        pwd isa Base.SecretBuffer && seekstart(pwd)
+        write(buf, pwd)
+        pwd isa Base.SecretBuffer && Base.shred!(pwd)
         write(buf, "}")
     end
 
     # Add extra auth parameters if provided
     if extraauth !== nothing
         (usr !== nothing || pwd !== nothing) && write(buf, ";")
-        if extraauth isa Base.SecretBuffer
-            seekstart(extraauth)
-            write(buf, read(extraauth, extraauth.size))
-            Base.shred!(extraauth)
-        else
-            write(buf, extraauth)
-        end
+        extraauth isa Base.SecretBuffer && seekstart(extraauth)
+        write(buf, extraauth)
+        extraauth isa Base.SecretBuffer && Base.shred!(extraauth)
     end
 
     return buf  # Will be shredded by API.connect -> SQLDriverConnect

--- a/src/dbinterface.jl
+++ b/src/dbinterface.jl
@@ -22,14 +22,49 @@ function clear!(conn::Connection)
 end
 
 # format usr, pwd, and extraauth into UID=user;PWD=pass;extraauth
-function getextraauth(usr::Union{AbstractString, Nothing}, pwd::Union{AbstractString, Nothing}, extraauth::Union{AbstractString, Nothing}) :: String
-    parts = [
-        usr === nothing ? nothing : "UID={$usr}",
-        pwd === nothing ? nothing : "PWD={$pwd}",
-        extraauth === nothing ? nothing : extraauth
-    ]
-    strings = filter(s -> s !== nothing, parts)
-    return join(strings, ";")
+# SECURITY: Returns SecretBuffer to keep credentials secure throughout the call chain
+function getextraauth(usr::Union{AbstractString, Base.SecretBuffer, Nothing},
+                      pwd::Union{AbstractString, Base.SecretBuffer, Nothing},
+                      extraauth::Union{AbstractString, Base.SecretBuffer, Nothing}) :: Base.SecretBuffer
+    buf = Base.SecretBuffer()
+
+    # Add username if provided
+    if usr !== nothing
+        write(buf, "UID={")
+        if usr isa Base.SecretBuffer
+            seekstart(usr)
+            write(buf, read(usr, usr.size))
+        else
+            write(buf, usr)
+        end
+        write(buf, "}")
+    end
+
+    # Add password if provided
+    if pwd !== nothing
+        usr !== nothing && write(buf, ";")
+        write(buf, "PWD={")
+        if pwd isa Base.SecretBuffer
+            seekstart(pwd)
+            write(buf, read(pwd, pwd.size))
+        else
+            write(buf, pwd)
+        end
+        write(buf, "}")
+    end
+
+    # Add extra auth parameters if provided
+    if extraauth !== nothing
+        (usr !== nothing || pwd !== nothing) && write(buf, ";")
+        if extraauth isa Base.SecretBuffer
+            seekstart(extraauth)
+            write(buf, read(extraauth, extraauth.size))
+        else
+            write(buf, extraauth)
+        end
+    end
+
+    return buf  # Will be shredded by API.connect -> SQLDriverConnect
 end
 
 """
@@ -38,9 +73,22 @@ end
 Construct a `Connection` type by connecting to a valid ODBC Connection or by specifying a datasource name or valid connection string.
 1st argument `dsn` can be either the name of a pre-defined ODBC Connection or a valid connection string.
 A great resource for building valid connection strings is [http://www.connectionstrings.com/](http://www.connectionstrings.com/).
-Takes optional keyword arguments `username`, `password`, and `extraauth`, which are used to specify auth parameters. `extraauth` is
-to allow you to pass a sensitive string to be appended verbatim to the end of the connection string, e.g. DB-specific auth token
-parameters.
+
+Takes optional keyword arguments `user`, `password`, and `extraauth`, which are used to specify auth parameters.
+For enhanced security, credentials (`user`, `password`, `extraauth`) can be provided as `Base.SecretBuffer` objects,
+which will be securely shredded (zeroed in memory) after use to minimize exposure of sensitive data in memory dumps
+or swap files.
+
+Note: The `dsn` parameter should not contain credentials as it is stored in the Connection object and displayed
+by the `show` method. Use the keyword arguments for credentials instead.
+
+# Security Best Practice
+For sensitive credentials, use `Base.SecretBuffer`:
+```julia
+pwd = Base.SecretBuffer("my_secret_password")
+conn = ODBC.Connection("DSN=mydb"; user="myuser", password=pwd)
+# pwd is automatically shredded after connection establishment
+```
 
 Note that connecting will use the currently "set" ODBC driver manager, which by default is iODBC on OSX, unixODBC on Linux, and
 the system driver manager on Windows. If you experience cryptic connection errors, it's probably worth checking with your ODBC
@@ -53,8 +101,9 @@ conn = ODBC.Connection(...)
 """
 function Connection(dsn::AbstractString; user=nothing, password=nothing, extraauth=nothing)
     connstr = occursin('=', dsn) ? dsn : "DSN=$dsn"
-    extraauth = getextraauth(user, password, extraauth)
-    internalconnection = API.connect(connstr, extraauth)
+    extraauth_buf = getextraauth(user, password, extraauth)
+    # extraauth_buf (SecretBuffer) will be shredded in API.connect -> SQLDriverConnect
+    internalconnection = API.connect(connstr, extraauth_buf)
     return Connection(internalconnection, dsn)
 end
 
@@ -68,9 +117,22 @@ Connection(dsn::AbstractString, usr, pwd) = Connection(dsn; user=usr, password=p
 Construct a `Connection` type by connecting to a valid ODBC Connection or by specifying a datasource name or valid connection string.
 1st argument `dsn` can be either the name of a pre-defined ODBC Connection or a valid connection string.
 A great resource for building valid connection strings is [http://www.connectionstrings.com/](http://www.connectionstrings.com/).
-Takes optional keyword arguments `username`, `password`, and `extraauth`, which are used to specify auth parameters. `extraauth` is
-to allow you to pass a sensitive string to be appended verbatim to the end of the connection string, e.g. DB-specific auth token
-parameters.
+
+Takes optional keyword arguments `user`, `password`, and `extraauth`, which are used to specify auth parameters.
+For enhanced security, credentials (`user`, `password`, `extraauth`) can be provided as `Base.SecretBuffer` objects,
+which will be securely shredded (zeroed in memory) after use to minimize exposure of sensitive data in memory dumps
+or swap files.
+
+Note: The `dsn` parameter should not contain credentials as it is stored in the Connection object and displayed
+by the `show` method. Use the keyword arguments for credentials instead.
+
+# Security Best Practice
+For sensitive credentials, use `Base.SecretBuffer`:
+```julia
+pwd = Base.SecretBuffer("my_secret_password")
+conn = DBInterface.connect(ODBC.Connection, "DSN=mydb"; user="myuser", password=pwd)
+# pwd is automatically shredded after connection establishment
+```
 
 Note that connecting will use the currently "set" ODBC driver manager, which by default is iODBC on OSX, unixODBC on Linux, and
 the system driver manager on Windows. If you experience cryptic connection errors, it's probably worth checking with your ODBC

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,9 @@ using Test, ODBC, DBInterface, Tables, Dates, DecFP, MariaDB_Connector_ODBC_jll,
         result_str = String(read(result, result.size))
         @test occursin("UID={testuser}", result_str)
         @test occursin("PWD={secret_password}", result_str)
+        
+        # test that pwd has been shredded
+        @test isempty(pwd)
 
         # Clean up
         Base.shred!(result)
@@ -36,6 +39,11 @@ using Test, ODBC, DBInterface, Tables, Dates, DecFP, MariaDB_Connector_ODBC_jll,
         @test occursin("UID={secret_usr}", result_str)
         @test occursin("PWD={secret_pwd}", result_str)
         @test occursin("token=abc123", result_str)
+
+        # test that pwd, usr, and extra have been shredded
+        @test isempty(pwd)
+        @test isempty(usr)
+        @test isempty(extra)
 
         Base.shred!(result)
     end
@@ -70,17 +78,20 @@ using Test, ODBC, DBInterface, Tables, Dates, DecFP, MariaDB_Connector_ODBC_jll,
     end
 
     @testset "API.connect with SecretBuffer" begin
-        # Test that connect function accepts SecretBuffer for extraauth
-        # DSN is a regular string (may be displayed), credentials are in extraauth
-        dsn = "DSN=test"
-        auth = Base.SecretBuffer("UID=user;PWD=pass")
+        usr = Base.SecretBuffer("root")
+        pword = Base.SecretBuffer("")
+        extraauth = Base.SecretBuffer("Option=67108864;CHARSET=utf8mb4")
+        auth = ODBC.getextraauth(usr, pword, extraauth)
+        conn = DBInterface.connect(ODBC.Connection, "Driver={ODBC_Test_MariaDB}", extraauth = auth)
+        
+        @test conn isa ODBC.Connection
+        DBInterface.close!(conn)
 
-        # We can't actually test the full connection without a database,
-        # but we can verify the function signature accepts SecretBuffer for extraauth
-        @test hasmethod(ODBC.API.connect, (String, Base.SecretBuffer))
-        @test hasmethod(ODBC.API.connect, (String, String))
-
-        Base.shred!(auth)
+        # test that the SecretBuffers have been shredded
+        @test isempty(usr)
+        @test isempty(pword)
+        @test isempty(extraauth)
+        @test isempty(auth)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ if Sys.islinux()
     if Int == Int32
         libpath = joinpath(expanduser("~"), "mariadb32/lib/libmaodbc.so")
     else
-        libpath = joinpath("/home/runner/mariadb64", "mariadb-connector-odbc-3.2.8-ubuntu-jammy-amd64/lib/mariadb/libmaodbc.so")
+        libpath = joinpath("/home/runner/mariadb64", "mariadb-connector-odbc-3.1.20-ubuntu-focal-amd64/lib/mariadb/libmaodbc.so")
     end
 elseif Sys.iswindows()
     if Int == Int32

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,89 @@
 using Test, ODBC, DBInterface, Tables, Dates, DecFP, MariaDB_Connector_ODBC_jll, MariaDB_Connector_C_jll
 
+# Test SecretBuffer support for secure credential handling
+@testset "SecretBuffer Support" begin
+    @testset "getextraauth with SecretBuffer" begin
+        # Test with SecretBuffer password
+        pwd = Base.SecretBuffer("secret_password")
+        usr = "testuser"
+
+        result = ODBC.getextraauth(usr, pwd, nothing)
+
+        @test result isa Base.SecretBuffer
+        @test result.size > 0
+
+        # Read the result to verify correctness
+        seekstart(result)
+        result_str = String(read(result, result.size))
+        @test occursin("UID={testuser}", result_str)
+        @test occursin("PWD={secret_password}", result_str)
+
+        # Clean up
+        Base.shred!(result)
+    end
+
+    @testset "getextraauth with all SecretBuffers" begin
+        pwd = Base.SecretBuffer("secret_pwd")
+        usr = Base.SecretBuffer("secret_usr")
+        extra = Base.SecretBuffer("token=abc123")
+
+        result = ODBC.getextraauth(usr, pwd, extra)
+
+        @test result isa Base.SecretBuffer
+
+        seekstart(result)
+        result_str = String(read(result, result.size))
+        @test occursin("UID={secret_usr}", result_str)
+        @test occursin("PWD={secret_pwd}", result_str)
+        @test occursin("token=abc123", result_str)
+
+        Base.shred!(result)
+    end
+
+    @testset "getextraauth with mixed types" begin
+        pwd = Base.SecretBuffer("secret")
+        usr = "normaluser"
+
+        result = ODBC.getextraauth(usr, pwd, nothing)
+        @test result isa Base.SecretBuffer
+
+        seekstart(result)
+        result_str = String(read(result, result.size))
+        @test occursin("UID={normaluser}", result_str)
+        @test occursin("PWD={secret}", result_str)
+
+        Base.shred!(result)
+    end
+
+    @testset "getextraauth backward compatibility" begin
+        # Test that regular strings still work
+        result = ODBC.getextraauth("user", "pass", nothing)
+
+        @test result isa Base.SecretBuffer
+
+        seekstart(result)
+        result_str = String(read(result, result.size))
+        @test occursin("UID={user}", result_str)
+        @test occursin("PWD={pass}", result_str)
+
+        Base.shred!(result)
+    end
+
+    @testset "API.connect with SecretBuffer" begin
+        # Test that connect function accepts SecretBuffer for extraauth
+        # DSN is a regular string (may be displayed), credentials are in extraauth
+        dsn = "DSN=test"
+        auth = Base.SecretBuffer("UID=user;PWD=pass")
+
+        # We can't actually test the full connection without a database,
+        # but we can verify the function signature accepts SecretBuffer for extraauth
+        @test hasmethod(ODBC.API.connect, (String, Base.SecretBuffer))
+        @test hasmethod(ODBC.API.connect, (String, String))
+
+        Base.shred!(auth)
+    end
+end
+
 tracefile = abspath(joinpath(@__DIR__, "odbc.log"))
 ODBC.setdebug(true, tracefile)
 @show ODBC.drivers()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,38 @@
 using Test, ODBC, DBInterface, Tables, Dates, DecFP, MariaDB_Connector_ODBC_jll, MariaDB_Connector_C_jll
 
+tracefile = abspath(joinpath(@__DIR__, "odbc.log"))
+ODBC.setdebug(true, tracefile)
+@show ODBC.drivers()
+@show ODBC.dsns()
+ODBC.setdebug(false)
+@test filesize(tracefile) > 0
+rm(tracefile)
+
+PLUGIN_DIR = joinpath(MariaDB_Connector_C_jll.artifact_dir, "lib", "mariadb", "plugin")
+if Sys.islinux()
+    if Int == Int32
+        libpath = joinpath(expanduser("~"), "mariadb32/lib/libmaodbc.so")
+    else
+        libpath = joinpath("/home/runner/mariadb64", "mariadb-connector-odbc-3.2.8-ubuntu-jammy-amd64/lib/mariadb/libmaodbc.so")
+    end
+elseif Sys.iswindows()
+    if Int == Int32
+        libpath = expanduser(joinpath("~", "mariadb-connector-odbc-3.1.7-win32", "maodbc.dll"))
+    else
+        @show readdir(expanduser(joinpath("~", "mariadb-connector-odbc-3.1.7-win64", "SourceDir", "MariaDB", "MariaDB ODBC Driver 64-bit")))
+        libpath = expanduser(joinpath("~", "mariadb-connector-odbc-3.1.7-win64", "SourceDir", "MariaDB", "MariaDB ODBC Driver 64-bit", "maodbc.dll"))
+    end
+else
+    libpath = MariaDB_Connector_ODBC_jll.libmaodbc_path
+end
+@show libpath
+@show isfile(libpath)
+ODBC.adddriver("ODBC_Test_MariaDB", libpath)
+ODBC.adddsn("ODBC_Test_DSN_MariaDB", "ODBC_Test_MariaDB"; SERVER="127.0.0.1", UID="root", PLUGIN_DIR=PLUGIN_DIR, Option=67108864, CHARSET="utf8mb4")
+
+conn = DBInterface.connect(ODBC.Connection, "ODBC_Test_DSN_MariaDB")
+DBInterface.close!(conn)
+
 # Test SecretBuffer support for secure credential handling
 @testset "SecretBuffer Support" begin
     @testset "getextraauth with SecretBuffer" begin
@@ -95,38 +128,6 @@ using Test, ODBC, DBInterface, Tables, Dates, DecFP, MariaDB_Connector_ODBC_jll,
     end
 end
 
-tracefile = abspath(joinpath(@__DIR__, "odbc.log"))
-ODBC.setdebug(true, tracefile)
-@show ODBC.drivers()
-@show ODBC.dsns()
-ODBC.setdebug(false)
-@test filesize(tracefile) > 0
-rm(tracefile)
-
-PLUGIN_DIR = joinpath(MariaDB_Connector_C_jll.artifact_dir, "lib", "mariadb", "plugin")
-if Sys.islinux()
-    if Int == Int32
-        libpath = joinpath(expanduser("~"), "mariadb32/lib/libmaodbc.so")
-    else
-        libpath = joinpath("/home/runner/mariadb64", "mariadb-connector-odbc-3.1.20-ubuntu-focal-amd64/lib/mariadb/libmaodbc.so")
-    end
-elseif Sys.iswindows()
-    if Int == Int32
-        libpath = expanduser(joinpath("~", "mariadb-connector-odbc-3.1.7-win32", "maodbc.dll"))
-    else
-        @show readdir(expanduser(joinpath("~", "mariadb-connector-odbc-3.1.7-win64", "SourceDir", "MariaDB", "MariaDB ODBC Driver 64-bit")))
-        libpath = expanduser(joinpath("~", "mariadb-connector-odbc-3.1.7-win64", "SourceDir", "MariaDB", "MariaDB ODBC Driver 64-bit", "maodbc.dll"))
-    end
-else
-    libpath = MariaDB_Connector_ODBC_jll.libmaodbc_path
-end
-@show libpath
-@show isfile(libpath)
-ODBC.adddriver("ODBC_Test_MariaDB", libpath)
-ODBC.adddsn("ODBC_Test_DSN_MariaDB", "ODBC_Test_MariaDB"; SERVER="127.0.0.1", UID="root", PLUGIN_DIR=PLUGIN_DIR, Option=67108864, CHARSET="utf8mb4")
-
-conn = DBInterface.connect(ODBC.Connection, "ODBC_Test_DSN_MariaDB")
-DBInterface.close!(conn)
 conn = DBInterface.connect(ODBC.Connection, "Driver={ODBC_Test_MariaDB};SERVER=127.0.0.1;PLUGIN_DIR=$PLUGIN_DIR;Option=67108864;CHARSET=utf8mb4;USER=root")
 
 DBInterface.execute(conn, "DROP DATABASE if exists mysqltest")


### PR DESCRIPTION
Currently, passwords / extraauth of connection strings are handled by AbstractString. Julia offers an excellent possibility to handle credentials by `Base.SecretBuffer`. (I came across this topic during a security review of a web application).
This PR introduces non-breaking support for `SecretBuffer`.
Disclaimer:
The PR is handcrafted and corrected/reviewed by AI. Docs and tests are mainly AI generated.