### PR TITLE
compatibility with mariadb connector 3.2.8

### DIFF
--- a/src/dbinterface.jl
+++ b/src/dbinterface.jl
@@ -340,21 +340,7 @@ function Cursor(stmt; iterate_rows::Bool=false, ignore_driver_row_count::Bool=fa
                 elsize = columnsizes[i]
                 for j = 1:rowsfetched
                     @inbounds ind = inds[j]
-                    if ind == API.SQL_NULL_DATA
-                        A[j] = missing
-                    else
-                        raw_bytes = unsafe_wrap(Array, pointer(data, cur), ind)
-                        count = length(raw_bytes)
-                        # strip trailing null bytes if it's a character/string data type
-                        # (Drivers often pad with \0, but Julia strings shouldn't embed them)
-                        if ctype == API.SQL_C_CHAR || ctype == API.SQL_C_WCHAR
-                            while count > 0 && raw_bytes[count] == 0x00
-                                count -= 1
-                            end
-                        end
-
-                        A[j] = jlcast(Base.nonmissingtype(T), view(raw_bytes, 1:count))
-                    end
+                    A[j] = ind == API.SQL_NULL_DATA ? missing : jlcast(Base.nonmissingtype(T), unsafe_wrap(Array, pointer(data, cur), ind))
                     cur += elsize
                 end
                 columns[i] = A

--- a/src/dbinterface.jl
+++ b/src/dbinterface.jl
@@ -283,7 +283,21 @@ function Cursor(stmt; iterate_rows::Bool=false, ignore_driver_row_count::Bool=fa
                 elsize = columnsizes[i]
                 for j = 1:rowsfetched
                     @inbounds ind = inds[j]
-                    A[j] = ind == API.SQL_NULL_DATA ? missing : jlcast(Base.nonmissingtype(T), unsafe_wrap(Array, pointer(data, cur), ind))
+                    if ind == API.SQL_NULL_DATA
+                        A[j] = missing
+                    else
+                        raw_bytes = unsafe_wrap(Array, pointer(data, cur), ind)
+                        count = length(raw_bytes)
+                        # strip trailing null bytes if it's a character/string data type
+                        # (Drivers often pad with \0, but Julia strings shouldn't embed them)
+                        if ctype == API.SQL_C_CHAR || ctype == API.SQL_C_WCHAR
+                            while count > 0 && raw_bytes[count] == 0x00
+                                count -= 1
+                            end
+                        end
+
+                        A[j] = jlcast(Base.nonmissingtype(T), view(raw_bytes, 1:count))
+                    end
                     cur += elsize
                 end
                 columns[i] = A

--- a/src/dbinterface.jl
+++ b/src/dbinterface.jl
@@ -340,7 +340,21 @@ function Cursor(stmt; iterate_rows::Bool=false, ignore_driver_row_count::Bool=fa
                 elsize = columnsizes[i]
                 for j = 1:rowsfetched
                     @inbounds ind = inds[j]
-                    A[j] = ind == API.SQL_NULL_DATA ? missing : jlcast(Base.nonmissingtype(T), unsafe_wrap(Array, pointer(data, cur), ind))
+                    if ind == API.SQL_NULL_DATA
+                        A[j] = missing
+                    else
+                        raw_bytes = unsafe_wrap(Array, pointer(data, cur), ind)
+                        count = length(raw_bytes)
+                        # strip trailing null bytes if it's a character/string data type
+                        # (Drivers often pad with \0, but Julia strings shouldn't embed them)
+                        if ctype == API.SQL_C_CHAR || ctype == API.SQL_C_WCHAR
+                            while count > 0 && raw_bytes[count] == 0x00
+                                count -= 1
+                            end
+                        end
+
+                        A[j] = jlcast(Base.nonmissingtype(T), view(raw_bytes, 1:count))
+                    end
                     cur += elsize
                 end
                 columns[i] = A

--- a/src/load.jl
+++ b/src/load.jl
@@ -20,14 +20,25 @@ function sqltype(conn, T)
         if i === nothing
             defaultT = "VARCHAR(255)"
         else
-            defaultT = types.TYPE_NAME[i] * "($(types.COLUMN_SIZE[i]))"
+            # Safeguard: Any driver returning exactly the maximum tiny/medium text range 
+            # for default VARCHAR triggers a standard 255 fallback, e.g. mariadb version 3.2
+            colsize = types.COLUMN_SIZE[i]
+            (colsize == 65535 || colsize == 16777215) && (colsize = 255)
+            defaultT = types.TYPE_NAME[i] * "($colsize)"
         end
         for jlT in BINDTYPES
             _, sqlT = bindtypes(jlT)
             i = findfirst(==(sqlT), types.DATA_TYPE)
             nm = i !== nothing ? types.TYPE_NAME[i] : defaultT
             if i !== nothing && types.CREATE_PARAMS[i] !== missing && nm != "DOUBLE" && nm != "FLOAT"
-                nm *= occursin(',', types.CREATE_PARAMS[i]) ? "($(typeprecision(jlT)),$(typescale(jlT)))" : "($(types.COLUMN_SIZE[i]))"
+                colsize = types.COLUMN_SIZE[i]
+                # Step down the explicit type bindings if they hit MariaDB max sizes
+                if (sqlT in (API.SQL_VARCHAR, API.SQL_VARBINARY, API.SQL_WVARCHAR)) && 
+                   (colsize == 65535 || colsize == 16777215)
+                    colsize = 255
+                end
+                
+                nm *= occursin(',', types.CREATE_PARAMS[i]) ? "($(typeprecision(jlT)),$(typescale(jlT)))" : "($colsize)"
             end
             conn.types[jlT] = nm
         end
@@ -42,7 +53,7 @@ function createtable(conn::Connection, nm::AbstractString, sch::Tables.Schema; d
     checkdupnames(names)
     # prevent row too large error by limiting column size for long text types
     # as some drivers (like mariadb-connectors-odbc 3.2.8) will return 65535
-    types = [replace(sqltype(conn, T), "65535" => "255") for T in sch.types]
+    types = [sqltype(conn, T) for T in sch.types]
     columns = (string(quoteidentifiers ? quoteid(conn, String(names[i])) : names[i], ' ', types[i], ' ', get(columnsuffix, names[i], "")) for i = 1:length(names))
     debug && @info "executing create table statement: `$createtableclause $nm ($(join(columns, ", ")))`"
     return DBInterface.execute(conn, "$createtableclause $nm ($(join(columns, ", ")))")

--- a/src/load.jl
+++ b/src/load.jl
@@ -40,7 +40,9 @@ checkdupnames(names) = length(unique(map(x->lowercase(String(x)), names))) == le
 function createtable(conn::Connection, nm::AbstractString, sch::Tables.Schema; debug::Bool=false, quoteidentifiers::Bool=true, createtableclause::AbstractString="CREATE TABLE", columnsuffix=Dict())
     names = sch.names
     checkdupnames(names)
-    types = [sqltype(conn, T) for T in sch.types]
+    # prevent row too large error by limiting column size for long text types
+    # as some drivers (like mariadb-connectors-odbc 3.2.8) will return 65535
+    types = [replace(sqltype(conn, T), "65535" => "255") for T in sch.types]
     columns = (string(quoteidentifiers ? quoteid(conn, String(names[i])) : names[i], ' ', types[i], ' ', get(columnsuffix, names[i], "")) for i = 1:length(names))
     debug && @info "executing create table statement: `$createtableclause $nm ($(join(columns, ", ")))`"
     return DBInterface.execute(conn, "$createtableclause $nm ($(join(columns, ", ")))")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -337,11 +337,17 @@ bindcol(stmt, i, b::Binding) = API.SQLBindCol(API.getptr(stmt), i,
     b.valuetype, pointer(b.value), b.bufferlength, b.strlen_or_indptr)
 
 function jlcast(::Type{T}, bytes) where {T <: DecFP.DecimalFloatingPoint}
-    x = rstrip(String(bytes), '\0')
+    x = rstrip(String(copy(bytes)), '\0')
     parse(T, x)
 end
 jlcast(::Type{Vector{UInt8}}, bytes) = copy(bytes)
-jlcast(::Type{String}, bytes) = String(bytes)
+function jlcast(::Type{String}, bytes)
+    count = length(bytes)
+    while count > 0 && bytes[count] == 0x00
+        count -= 1
+    end
+    String(view(bytes, 1:count))
+end
 
 # given the SQL type as described by the driver library
 # what is the C storage needed for data transfer, and


### PR DESCRIPTION
Currently usage of the latest mariadb odbc connector fails due to two reasons
- the termination character is not stripped off
- the max value for characters in a row is returned as 65535, which leads to a `Column length too big` error

Both root causes are addressed with this PR.

Superseded by #403, which includes the safe type-size fix from #401 and preserves valid trailing NUL data. The global NUL stripping in this PR was not merged.
